### PR TITLE
docs: sync public benchmark pack v1 honesty evidence

### DIFF
--- a/app/vision.html
+++ b/app/vision.html
@@ -111,8 +111,8 @@
   <div class="grid-2">
     <article class="card">
       <h3>Public curriculum families <span class="badge badge-training">shipped</span></h3>
-      <p>The public benchmark pack ships 12 episodes across 6 families derived from the current apprentice scenarios. These are all student-visible and safe to train on.</p>
-      <p style="margin-top: 0.5rem;"><small>Sources: landing-story clarity, curriculum/holdout separation, score-delta legibility, proof-bundle visibility, demo honesty, failure-to-curriculum promotion.</small></p>
+      <p>The public benchmark pack ships 14 episodes across 7 families derived from the current apprentice scenarios. These are all student-visible and safe to train on.</p>
+      <p style="margin-top: 0.5rem;"><small>Sources: landing-story clarity, curriculum/holdout separation, score-delta legibility, proof-bundle visibility, demo honesty, failure-to-curriculum promotion, and Playwright-informed UI regression.</small></p>
     </article>
     <article class="card">
       <h3>Teacher-only holdout extension <span class="badge badge-holdout">teacher-only</span></h3>

--- a/benchmarks/public-pack-v1/benchmark-pack.json
+++ b/benchmarks/public-pack-v1/benchmark-pack.json
@@ -13,7 +13,9 @@
     ],
     "episode_registry": "data/episode-registry/public-benchmark-pack-v1.json",
     "public_episode_count": 14,
-    "public_family_count": 7
+    "public_family_count": 7,
+    "public_provenance_coverage_pct": 100.0,
+    "family_readiness_coverage_pct": 100.0
   },
   "execution_policy": {
     "student_visible_only": true,
@@ -447,7 +449,7 @@
       "student_prompt": "Write or improve a regression check for the scenarios/curriculum page using Playwright best-practice locator strategies: getByRole, getByText, or getByLabel instead of brittle CSS selectors. The check should verify that public curriculum cards render and holdout cards are visually distinct.",
       "constraints": [
         "Target an existing Role Foundry screen (app/scenarios.html)",
-        "Use user-visible locators only — no data-testid or CSS-path selectors",
+        "Use user-visible locators only \u2014 no data-testid or CSS-path selectors",
         "Do not claim a full Playwright CI harness ships if it does not",
         "Leave a regression-check receipt"
       ],
@@ -462,7 +464,7 @@
         "locator strategy notes"
       ],
       "public_checks": [
-        "Locators use role, text, or label — not CSS selectors or test IDs",
+        "Locators use role, text, or label \u2014 not CSS selectors or test IDs",
         "Check targets the real curriculum page, not a hypothetical surface",
         "Check distinguishes public curriculum cards from holdout cards",
         "No overclaim about Playwright CI pipeline if one does not exist"
@@ -488,7 +490,7 @@
       "student_prompt": "Write or improve a regression check for the run detail page that follows Playwright test-isolation best practices: the check should not depend on state left by other checks, should set up its own data context, and should verify proof-bundle rendering independently.",
       "constraints": [
         "Target an existing Role Foundry screen (app/run.html)",
-        "Each check must be independent — no shared mutable state between checks",
+        "Each check must be independent \u2014 no shared mutable state between checks",
         "Keep the scope to one check or one small check file",
         "Do not invent runtime artifact backends that do not exist"
       ],
@@ -559,13 +561,17 @@
         "label": "Public/teacher split integrity",
         "status": "pass",
         "included_student_visible_family_count": 7,
-        "blocked_teacher_only_family_count": 3
+        "blocked_teacher_only_family_count": 3,
+        "leak_audit_status": "pass",
+        "teacher_only_field_hits": 0,
+        "teacher_only_token_hits": 0
       },
       "B005": {
         "label": "Provenance coverage",
         "status": "pass",
         "provenance_mapped_episode_count": 14,
-        "expectation": "Every public episode cites its public source scenario and contract docs/specs."
+        "expectation": "Every public episode cites its public source scenario and contract docs/specs.",
+        "actual_provenance_coverage_pct": 100.0
       },
       "B006": {
         "label": "Promotion readiness clarity",
@@ -574,8 +580,32 @@
         "blocked_claims": [
           "sealed certification",
           "fresh hidden-eval integrity claims"
+        ],
+        "family_readiness_coverage_count": 10,
+        "family_readiness_state_counts": {
+          "benchmark_ready": 7,
+          "rewrite_before_holdout_promotion": 3
+        },
+        "allowed_readiness_states": [
+          "draft",
+          "benchmark_ready",
+          "rewrite_before_holdout_promotion",
+          "blocked"
         ]
       }
     }
+  },
+  "integrity_audit": {
+    "phase": "B",
+    "status": "pass",
+    "teacher_only_field_hits": 0,
+    "teacher_only_token_hits": 0,
+    "blocked_family_count": 3,
+    "scanned_artifacts": [
+      "benchmarks/public-pack-v1/benchmark-pack.json",
+      "benchmarks/public-pack-v1/episode-family-registry.json",
+      "data/episode-registry/public-benchmark-pack-v1.json"
+    ],
+    "notes": "Tracked public benchmark-pack artifacts contain no teacher-only prompt text or grading-rubric content."
   }
 }

--- a/benchmarks/public-pack-v1/episode-family-registry.json
+++ b/benchmarks/public-pack-v1/episode-family-registry.json
@@ -13,7 +13,14 @@
     "public_pack_rule": "Only benchmark_ready + student_visible families may appear in public-benchmark-pack-v1.",
     "blocked_rule": "Any family rooted in repo-visible holdout or teacher-only material is blocked_pending_rewrite until a fresh teacher-only version exists outside the public pack.",
     "certification_note": "public-benchmark-pack-v1 is suitable for public training and regression checks. It is not a sealed certification exam.",
-    "promotion_policy": "Every candidate family must have explicit promotion_criteria. A family with zero criteria is not promotable. Blocked families document what must change before promotion. Benchmark-ready families document which criteria were satisfied."
+    "promotion_policy": "Every candidate family must have explicit promotion_criteria. A family with zero criteria is not promotable. Blocked families document what must change before promotion. Benchmark-ready families document which criteria were satisfied.",
+    "allowed_readiness_states": [
+      "draft",
+      "benchmark_ready",
+      "rewrite_before_holdout_promotion",
+      "blocked"
+    ],
+    "readiness_state_policy": "Every candidate family must declare readiness_state using the allowed readiness-state set. Public-benchmark-pack-v1 may include only families whose readiness_state is benchmark_ready. Families derived from repo-visible holdout framing must be marked rewrite_before_holdout_promotion until fresh teacher-only wording exists outside the public pack."
   },
   "families": [
     {
@@ -28,7 +35,9 @@
         "rubric_template_exists": true,
         "not_repo_visible_holdout": true
       },
-      "source_seed_scenarios": ["t1"],
+      "source_seed_scenarios": [
+        "t1"
+      ],
       "title": "Landing story rewrite",
       "benchmark_goal": "Make the apprentice loop obvious in the first screenful instead of sounding like a generic agent platform.",
       "loop_stage": "public_curriculum",
@@ -50,7 +59,8 @@
         "States the apprentice is building Role Foundry itself",
         "Avoids generic platform copy and fake live claims"
       ],
-      "notes": "Public-safe because it derives only from student-visible curriculum."
+      "notes": "Public-safe because it derives only from student-visible curriculum.",
+      "readiness_state": "benchmark_ready"
     },
     {
       "id": "rf.frontend-apprentice.public.curriculum-split",
@@ -64,7 +74,9 @@
         "rubric_template_exists": true,
         "not_repo_visible_holdout": true
       },
-      "source_seed_scenarios": ["t2"],
+      "source_seed_scenarios": [
+        "t2"
+      ],
       "title": "Curriculum split clarity",
       "benchmark_goal": "Make student-visible curriculum versus teacher-only evaluation surfaces legible without disclosing teacher prompts.",
       "loop_stage": "public_curriculum",
@@ -84,7 +96,8 @@
         "Student prompt pack references public curriculum only",
         "No teacher-only prompt text or rubric appears in the student view"
       ],
-      "notes": "Public-safe because it focuses on the contract boundary, not hidden prompt contents."
+      "notes": "Public-safe because it focuses on the contract boundary, not hidden prompt contents.",
+      "readiness_state": "benchmark_ready"
     },
     {
       "id": "rf.frontend-apprentice.public.score-deltas",
@@ -98,7 +111,9 @@
         "rubric_template_exists": true,
         "not_repo_visible_holdout": true
       },
-      "source_seed_scenarios": ["t3"],
+      "source_seed_scenarios": [
+        "t3"
+      ],
       "title": "Visible score deltas",
       "benchmark_goal": "Make improvement legible with concrete iteration deltas instead of vague better/worse claims.",
       "loop_stage": "public_curriculum",
@@ -118,7 +133,8 @@
         "Shows concrete score movement instead of vibes language",
         "Keeps honesty about demo-only versus live-mode status"
       ],
-      "notes": "Public-safe because score deltas can be shown without exposing hidden prompts."
+      "notes": "Public-safe because score deltas can be shown without exposing hidden prompts.",
+      "readiness_state": "benchmark_ready"
     },
     {
       "id": "rf.frontend-apprentice.public.proof-bundle",
@@ -132,7 +148,9 @@
         "rubric_template_exists": true,
         "not_repo_visible_holdout": true
       },
-      "source_seed_scenarios": ["t4"],
+      "source_seed_scenarios": [
+        "t4"
+      ],
       "title": "Proof bundle legibility",
       "benchmark_goal": "Attach receipts that let a judge inspect what changed, what policy applied, and what evidence exists.",
       "loop_stage": "public_curriculum",
@@ -153,7 +171,8 @@
         "A strong run leaves behind auditable receipts",
         "No fake artifact plumbing claims are introduced"
       ],
-      "notes": "Public-safe because the bundle is meant for judge inspection already."
+      "notes": "Public-safe because the bundle is meant for judge inspection already.",
+      "readiness_state": "benchmark_ready"
     },
     {
       "id": "rf.frontend-apprentice.public.demo-honesty",
@@ -167,7 +186,9 @@
         "rubric_template_exists": true,
         "not_repo_visible_holdout": true
       },
-      "source_seed_scenarios": ["t5"],
+      "source_seed_scenarios": [
+        "t5"
+      ],
       "title": "Demo-mode honesty",
       "benchmark_goal": "Keep the slice narrow and honest: no fake live OAuth, no fake control-plane UI state, no decorative partner work.",
       "loop_stage": "public_curriculum",
@@ -187,7 +208,8 @@
         "Does not claim auth, Privy, or partner-track functionality that is not implemented",
         "Keeps the requested slice narrow instead of thrashing the repo"
       ],
-      "notes": "Public-safe because the benchmark is about honesty under pressure, not hidden adversarial prompts."
+      "notes": "Public-safe because the benchmark is about honesty under pressure, not hidden adversarial prompts.",
+      "readiness_state": "benchmark_ready"
     },
     {
       "id": "rf.frontend-apprentice.public.failure-to-curriculum",
@@ -201,7 +223,9 @@
         "rubric_template_exists": true,
         "not_repo_visible_holdout": true
       },
-      "source_seed_scenarios": ["t6"],
+      "source_seed_scenarios": [
+        "t6"
+      ],
       "title": "Failure-to-curriculum promotion",
       "benchmark_goal": "Promote sanitized public failure themes into curriculum without leaking teacher-only prompt text or grading internals.",
       "loop_stage": "flywheel",
@@ -221,7 +245,8 @@
         "Teacher-only prompt text is not quoted or paraphrased too specifically",
         "The next student prompt pack references only public curriculum themes"
       ],
-      "notes": "Public-safe because the promotion target is the sanitized lesson, not the sealed exam text."
+      "notes": "Public-safe because the promotion target is the sanitized lesson, not the sealed exam text.",
+      "readiness_state": "benchmark_ready"
     },
     {
       "id": "rf.frontend-apprentice.public.playwright-regression",
@@ -235,7 +260,9 @@
         "rubric_template_exists": true,
         "not_repo_visible_holdout": true
       },
-      "source_seed_scenarios": ["t7"],
+      "source_seed_scenarios": [
+        "t7"
+      ],
       "title": "Playwright-informed UI regression",
       "benchmark_goal": "Apply Playwright best-practice patterns to existing Role Foundry screens: user-visible locators, test isolation, and honest regression-check receipts.",
       "loop_stage": "public_curriculum",
@@ -264,7 +291,8 @@
         "Regression check targets an existing Role Foundry screen, not a hypothetical surface",
         "No claim that a full Playwright harness ships if it does not"
       ],
-      "notes": "Source-backed by Playwright public documentation (Apache-2.0). Episodes are RF-authored, not copied from Playwright docs."
+      "notes": "Source-backed by Playwright public documentation (Apache-2.0). Episodes are RF-authored, not copied from Playwright docs.",
+      "readiness_state": "benchmark_ready"
     },
     {
       "id": "rf.frontend-apprentice.blocked.teacher-only-h1",
@@ -280,14 +308,17 @@
         "fresh_non_disclosed_wording": false,
         "stored_outside_public_pack": false
       },
-      "source_seed_scenarios": ["h1"],
+      "source_seed_scenarios": [
+        "h1"
+      ],
       "title": "Teacher-only family derived from current holdout h1",
       "blocked_reason": "The current repo already discloses this holdout family's framing, so it cannot honestly be promoted as a public-safe benchmark or sealed evaluation family.",
       "rewrite_requirements": [
         "Create a fresh teacher-only family with new wording and rubric",
         "Store teacher-only prompt text outside the public benchmark pack",
         "Expose only a sanitized public failure theme after evaluation"
-      ]
+      ],
+      "readiness_state": "rewrite_before_holdout_promotion"
     },
     {
       "id": "rf.frontend-apprentice.blocked.teacher-only-h2",
@@ -303,14 +334,17 @@
         "fresh_non_disclosed_wording": false,
         "stored_outside_public_pack": false
       },
-      "source_seed_scenarios": ["h2"],
+      "source_seed_scenarios": [
+        "h2"
+      ],
       "title": "Teacher-only family derived from current holdout h2",
       "blocked_reason": "The exam-integrity framing is already visible in the public repo, so a public benchmark pack cannot claim this family is sealed. It needs a rewrite and separate teacher-only storage.",
       "rewrite_requirements": [
         "Write a new teacher-only prompt family with non-public wording",
         "Keep the grading rubric outside student-visible artifacts",
         "Promote only sanitized lesson text into public curriculum"
-      ]
+      ],
+      "readiness_state": "rewrite_before_holdout_promotion"
     },
     {
       "id": "rf.frontend-apprentice.blocked.teacher-only-h3",
@@ -326,14 +360,25 @@
         "fresh_non_disclosed_wording": false,
         "stored_outside_public_pack": false
       },
-      "source_seed_scenarios": ["h3"],
+      "source_seed_scenarios": [
+        "h3"
+      ],
       "title": "Teacher-only family derived from current holdout h3",
       "blocked_reason": "This adversarial low-churn family is already described in the public repo, so it is teacher-only at best and should not ship in a public benchmark pack until rewritten.",
       "rewrite_requirements": [
         "Author a fresh teacher-only variant that is not already disclosed publicly",
         "Keep the evaluation prompt and scoring rubric outside the public repo",
         "Publish only the public-safe lesson after scoring"
-      ]
+      ],
+      "readiness_state": "rewrite_before_holdout_promotion"
     }
-  ]
+  ],
+  "readiness_summary": {
+    "family_count": 10,
+    "coverage_pct": 100.0,
+    "state_counts": {
+      "benchmark_ready": 7,
+      "rewrite_before_holdout_promotion": 3
+    }
+  }
 }

--- a/data/episode-registry/public-benchmark-pack-v1.json
+++ b/data/episode-registry/public-benchmark-pack-v1.json
@@ -12,6 +12,12 @@
       "seed/role-foundry-apprentice.json",
       "benchmarks/public-pack-v1/benchmark-pack.json",
       "benchmarks/public-pack-v1/episode-family-registry.json"
+    ],
+    "allowed_readiness_states": [
+      "draft",
+      "benchmark_ready",
+      "rewrite_before_holdout_promotion",
+      "blocked"
     ]
   },
   "coverage": {
@@ -19,7 +25,10 @@
     "benchmark_ready_family_count": 7,
     "rubric_template_count": 7,
     "rubric_mapped_episode_count": 14,
-    "provenance_mapped_episode_count": 14
+    "provenance_mapped_episode_count": 14,
+    "public_provenance_coverage_pct": 100.0,
+    "family_readiness_coverage_count": 10,
+    "family_readiness_coverage_pct": 100.0
   },
   "rubric_templates": [
     {
@@ -669,5 +678,26 @@
         "notes": "Source-backed by Playwright public documentation (Apache-2.0). Episode is original RF-authored work informed by Playwright best practices; no Playwright prose is copied verbatim."
       }
     }
-  ]
+  ],
+  "integrity_audit": {
+    "phase": "B",
+    "status": "pass",
+    "teacher_only_field_hits": 0,
+    "teacher_only_token_hits": 0,
+    "blocked_family_count": 3,
+    "scanned_artifacts": [
+      "benchmarks/public-pack-v1/benchmark-pack.json",
+      "benchmarks/public-pack-v1/episode-family-registry.json",
+      "data/episode-registry/public-benchmark-pack-v1.json"
+    ],
+    "notes": "Tracked public benchmark-pack artifacts contain no teacher-only prompt text or grading-rubric content."
+  },
+  "readiness_summary": {
+    "family_count": 10,
+    "coverage_pct": 100.0,
+    "state_counts": {
+      "benchmark_ready": 7,
+      "rewrite_before_holdout_promotion": 3
+    }
+  }
 }

--- a/data/episode-registry/source-buckets.json
+++ b/data/episode-registry/source-buckets.json
@@ -11,25 +11,44 @@
       "label": "Public training curriculum",
       "visibility": "student_visible",
       "status": "active",
-      "scenario_ids": ["t1", "t2", "t3", "t4", "t5", "t6", "t7"],
+      "scenario_ids": [
+        "t1",
+        "t2",
+        "t3",
+        "t4",
+        "t5",
+        "t6",
+        "t7"
+      ],
       "family_id_prefix": "rf.frontend-apprentice.public.",
       "family_count": 7,
-      "pack_refs": ["benchmarks/public-pack-v1/benchmark-pack.json"],
-      "registry_refs": ["data/episode-registry/public-benchmark-pack-v1.json"],
-      "notes": "All six public families are benchmark_ready and ship in public-benchmark-pack-v1."
+      "pack_refs": [
+        "benchmarks/public-pack-v1/benchmark-pack.json"
+      ],
+      "registry_refs": [
+        "data/episode-registry/public-benchmark-pack-v1.json"
+      ],
+      "notes": "All seven public families are benchmark_ready and ship in public-benchmark-pack-v1."
     },
     {
       "id": "blocked-teacher-only",
       "label": "Blocked teacher-only families (repo-visible, pending rewrite)",
       "visibility": "teacher_only",
       "status": "blocked_pending_rewrite",
-      "scenario_ids": ["h1", "h2", "h3"],
+      "scenario_ids": [
+        "h1",
+        "h2",
+        "h3"
+      ],
       "family_id_prefix": "rf.frontend-apprentice.blocked.",
       "family_count": 3,
       "pack_refs": [],
-      "registry_refs": ["benchmarks/public-pack-v1/episode-family-registry.json"],
+      "registry_refs": [
+        "benchmarks/public-pack-v1/episode-family-registry.json"
+      ],
       "blocked_reason": "Current repo already discloses framing for h1/h2/h3. Cannot honestly claim these as sealed or promote to teacher-only benchmark status until rewritten with fresh non-repo-visible wording.",
-      "notes": "Listed in the family registry as blocked_pending_rewrite. Not included in any benchmark pack."
+      "notes": "Listed in the family registry as rewrite_before_holdout_promotion (legacy status: blocked_pending_rewrite). Not included in any benchmark pack.",
+      "readiness_state": "rewrite_before_holdout_promotion"
     },
     {
       "id": "local-private-holdout",
@@ -39,9 +58,12 @@
       "scenario_ids": [],
       "family_id_prefix": "rf.frontend-apprentice.holdout.",
       "family_count": 0,
-      "pack_refs": ["benchmarks/private-holdout-pack-template.json"],
+      "pack_refs": [
+        "benchmarks/private-holdout-pack-template.json"
+      ],
       "registry_refs": [],
-      "notes": "Template exists at benchmarks/private-holdout-pack-template.json. Actual holdout episodes are authored locally in a gitignored manifest. No episodes are committed to the repo. This bucket has zero committed families."
+      "notes": "Template exists at benchmarks/private-holdout-pack-template.json. Actual holdout episodes are authored locally in a gitignored manifest. No episodes are committed to the repo. This bucket has zero committed families.",
+      "readiness_state": "blocked"
     }
   ],
   "completeness": {
@@ -50,7 +72,18 @@
     "blocked_buckets": 1,
     "local_only_buckets": 1,
     "all_seed_scenarios_covered": true,
-    "seed_scenario_ids": ["t1", "t2", "t3", "t4", "t5", "t6", "t7", "h1", "h2", "h3"],
+    "seed_scenario_ids": [
+      "t1",
+      "t2",
+      "t3",
+      "t4",
+      "t5",
+      "t6",
+      "t7",
+      "h1",
+      "h2",
+      "h3"
+    ],
     "notes": "Every scenario in seed/role-foundry-apprentice.json maps to exactly one bucket."
   }
 }

--- a/docs/dataset-episode-registry.md
+++ b/docs/dataset-episode-registry.md
@@ -2,7 +2,7 @@
 
 `data/episode-registry/public-benchmark-pack-v1.json` is the **companion registry** for the public benchmark pack.
 
-It exists for one reason: the benchmark pack manifest is good at telling the student what to do, but Phase B also needs an audit surface for **how each public episode is judged and where it came from**.
+It exists for one reason: the benchmark pack manifest is good at telling the student what to do, but Phase B also needs an audit surface for **how each public episode is judged, where it came from, whether it stayed public-safe, and whether the family is actually ready to promote**.
 
 ## What this registry records
 
@@ -23,6 +23,34 @@ Each rubric template includes:
 - a short description of what the dimension is judging
 - pass/fail signals that stay public-safe
 
+At the registry level it also records:
+
+- **14 public episodes** mapped into the registry
+- **7 benchmark-ready public families**
+- **14/14 provenance mappings**
+- **100% public provenance coverage**
+- **100% family readiness coverage**
+- the **integrity audit** outcome for tracked public pack artifacts
+
+## Readiness states
+
+The family registry now exposes an explicit readiness-state layer so Phase B does not have to infer promotion clarity from prose alone.
+
+Allowed readiness states are:
+
+- `draft`
+- `benchmark_ready`
+- `rewrite_before_holdout_promotion`
+- `blocked`
+
+Current state for the public benchmark-pack path:
+
+- `7` families are `benchmark_ready`
+- `3` families are `rewrite_before_holdout_promotion`
+- `0` committed families use `draft` or `blocked`
+
+The legacy family `status` field still exists for compatibility, but the readiness state is the clearer promotion-planning signal.
+
 ## What this registry does **not** contain
 
 It does **not** contain:
@@ -36,18 +64,20 @@ That material belongs only in the local gitignored private-holdout path.
 
 ## Why it matters
 
-This registry makes four previously implicit claims explicit:
+This registry makes five Phase B claims explicit instead of implied:
 
 1. **rubric completeness** — every shipped public episode maps to a complete public rubric
 2. **weight normalization** — every public rubric sums to `1.0`
 3. **provenance coverage** — every shipped public episode traces back to public curriculum
-4. **promotion clarity** — the public pack is ready to promote for public regression/training use, not for sealed certification
+4. **leak-audit clarity** — tracked public pack artifacts record zero teacher-only field/token hits
+5. **promotion clarity** — every candidate family has an explicit readiness state
 
 ## Audit commands
 
 ```bash
-python3 -m unittest tests/test_public_benchmark_pack_v1.py
-python3 -m unittest tests/test_private_holdout_separation.py
+python3 -m unittest tests/test_public_benchmark_pack_v1.py -v
+python3 -m unittest tests/test_dataset_flywheel_phase_g.py -v
+python3 -m unittest tests/test_private_holdout_separation.py -v
 ```
 
 If those pass, the public pack still has:
@@ -57,3 +87,5 @@ If those pass, the public pack still has:
 - complete public rubric coverage
 - normalized public weights
 - full public provenance coverage
+- explicit readiness states across all candidate families
+- zero teacher-only leakage in tracked public pack artifacts

--- a/docs/dataset-flywheel.md
+++ b/docs/dataset-flywheel.md
@@ -12,9 +12,9 @@ promotion policy, holdout safety, and role-pack separation work together.
 
 | Bucket | Status | Families |
 |--------|--------|----------|
-| `public-training` | active | 6 (t1–t6) |
-| `blocked-teacher-only` | blocked_pending_rewrite | 3 (h1–h3) |
-| `local-private-holdout` | local_only | 0 committed |
+| `public-training` | active | 7 (t1–t7) |
+| `blocked-teacher-only` | blocked_pending_rewrite / readiness=`rewrite_before_holdout_promotion` | 3 (h1–h3) |
+| `local-private-holdout` | local_only / readiness=`blocked` | 0 committed |
 
 Every scenario in `seed/role-foundry-apprentice.json` maps to exactly one bucket.
 
@@ -23,19 +23,22 @@ Every scenario in `seed/role-foundry-apprentice.json` maps to exactly one bucket
 **Requirement:** Every candidate family must have explicit `promotion_criteria`.
 Families lacking criteria = 0.
 
-**Current state (passing):** All 9 families (6 benchmark_ready + 3 blocked)
+**Current state (passing):** All 10 families (7 benchmark-ready + 3 blocked)
 now carry `promotion_criteria` in
 `benchmarks/public-pack-v1/episode-family-registry.json`.
 
 - Benchmark-ready families: all base criteria satisfied (true)
 - Blocked families: at least one criterion is false, making the block machine-readable
+- Every family now also carries an explicit `readiness_state`
 
 ## G003 — Holdout promotion safety
 
 **Requirement:** Families promoted to teacher-only benchmark status while
 marked repo-visible/leaky = 0.
 
-**Current state (passing):** h1, h2, h3 remain `blocked_pending_rewrite`.
+**Current state (passing):** h1, h2, h3 remain legacy-status
+`blocked_pending_rewrite` and readiness-state
+`rewrite_before_holdout_promotion`.
 Their `blocked_reason` documents that the repo already discloses their framing.
 None are included in any benchmark pack.
 

--- a/docs/public-benchmark-pack-v1.md
+++ b/docs/public-benchmark-pack-v1.md
@@ -2,16 +2,16 @@
 
 This repo now has a first **public-safe benchmark pack** for the Frontend Apprentice.
 
-The important honesty line:
+The honesty line is simple:
 
 - **benchmark-ready now:** public curriculum families only
-- **blocked / pending rewrite:** any teacher-only or holdout-derived family whose framing is already visible in this public repo
+- **blocked / rewrite-needed:** any teacher-only or holdout-derived family whose framing is already visible in this public repo
 - **not claimed:** sealed certification, partner-track work, or fresh hidden-eval integrity from the current public holdout families
 - **plainly:** this pack is **not a sealed certification** pack
 
 ## What is benchmark-ready now
 
-`benchmarks/public-pack-v1/benchmark-pack.json` contains **12 concrete student-visible episodes** across **6 public-ready families**:
+`benchmarks/public-pack-v1/benchmark-pack.json` currently contains **14 concrete student-visible episodes** across **7 public-ready families**:
 
 - `rf.frontend-apprentice.public.landing-story`
   - make the dogfood apprentice loop obvious
@@ -25,6 +25,8 @@ The important honesty line:
   - refuse fake live claims and keep slices narrow
 - `rf.frontend-apprentice.public.failure-to-curriculum`
   - promote sanitized lessons into public curriculum
+- `rf.frontend-apprentice.public.playwright-regression`
+  - add source-backed public UI regression tasks without inventing a fake Playwright harness
 
 These are appropriate for:
 
@@ -37,35 +39,39 @@ These are appropriate for:
 
 `data/episode-registry/public-benchmark-pack-v1.json` is the companion registry for the pack.
 
-It adds the missing audit surface that the original manifest only implied:
+It carries the audit surface the student-facing manifest alone cannot:
 
-- **6 public rubric templates** — one per public family
+- **7 public rubric templates** — one per public family
 - **normalized weights** — every template sums to `1.0`
-- **12/12 rubric mappings** — every shipped public episode points at a complete public rubric
-- **12/12 provenance mappings** — every shipped public episode cites its public training seed scenario plus public spec/doc references
+- **14/14 rubric mappings** — every shipped public episode points at a complete public rubric
+- **14/14 provenance mappings** — every shipped public episode cites its public training seed scenario plus public spec/doc references
+- **100% family readiness coverage** — every candidate family has an explicit readiness state
 - **no teacher-only fields** — the registry stays public-safe and never includes hidden prompt text or teacher-side scoring rubrics
 
 For the registry contract itself, see `docs/dataset-episode-registry.md`.
 
 ## Phase B acceptance snapshot
 
-The clean public-pack lane now carries explicit **B001–B006** status instead of leaving them implicit:
+The pack now leaves explicit **B001–B006** evidence behind instead of asking a reader to infer it:
 
 - **B001 — Public episode count:** pass
-  - 12 public episodes shipped
-  - current floor remains 10
+  - 14 public episodes shipped across 7 families
+  - floor remains `>= 8` episodes across `>= 3` families in the forward spec, and spec 008 still exceeds its own `>= 10` episode bar
 - **B002 — Rubric completeness:** pass
-  - 6 public rubric templates cover all 12 public episodes
+  - 7 public rubric templates cover all 14 public episodes
 - **B003 — Weight normalization:** pass
   - every public rubric template sums to `1.0`
 - **B004 — Public/teacher split integrity:** pass
-  - 6 `student_visible` families included
-  - 3 `teacher_only` families remain `blocked_pending_rewrite` and excluded
+  - 7 `student_visible` families included
+  - 3 `teacher_only` families remain excluded
+  - leak audit outcome: `pass` with `0` teacher-only field hits and `0` teacher-only token hits in tracked public pack artifacts
 - **B005 — Provenance coverage:** pass
-  - 12/12 public episodes cite training-seed + public spec/doc provenance
+  - 14/14 public episodes cite training-seed + public spec/doc provenance
+  - actual public provenance coverage: `100%`
 - **B006 — Promotion readiness clarity:** pass, with named limits
-  - ready to promote as the repo's **public-safe benchmark pack** for public regression/training use
+  - ready to promote as the repo’s **public-safe benchmark pack** for public regression/training use
   - still blocked from sealed certification or fresh hidden-eval integrity claims
+  - every family declares an explicit readiness state from the allowed set: `draft`, `benchmark_ready`, `rewrite_before_holdout_promotion`, `blocked`
 
 ## What is blocked
 
@@ -76,24 +82,24 @@ They are blocked because the current repo already exposes their framing. That me
 - sealed eval families
 - public-safe benchmark families
 
-Each blocked family is marked `blocked_pending_rewrite` and includes rewrite requirements.
+For compatibility, the legacy family `status` remains `blocked_pending_rewrite`, while the explicit readiness state for promotion planning is `rewrite_before_holdout_promotion`.
 
 ## Why this split matters
 
 The existing repo proves the **contract** for student-visible vs teacher-only separation.
 
-It does **not** yet give us a clean public sealed-eval pack, because the current holdout families are already repo-visible. So the right move is:
+It does **not** give us a clean public sealed-eval pack, because the current holdout families are already repo-visible. So the honest move is:
 
 1. ship a real public benchmark pack now
 2. keep teacher-only / holdout-derived families out of that pack
-3. add public rubrics + provenance so the pack is audit-friendly instead of hand-wavy
+3. attach public rubrics, provenance, leak-audit evidence, and readiness states so the pack is audit-friendly instead of hand-wavy
 4. rewrite fresh teacher-only families later outside the public student pack
 
 That keeps the benchmark story honest.
 
 ## Local private holdout path
 
-Fresh teacher-only holdouts now have a **local-only scaffold**:
+Fresh teacher-only holdouts still have a **local-only scaffold**:
 
 - public schema template: `benchmarks/private-holdout-pack-template.json`
 - private local manifest path: `benchmarks/private-holdout-pack/holdout-manifest.json`
@@ -120,10 +126,10 @@ Use the pack like this:
 Run:
 
 ```bash
-python3 -m unittest tests/test_public_benchmark_pack_v1.py
-python3 -m unittest tests/test_private_holdout_separation.py
-python3 scripts/holdout_author.py audit
-python3 -m unittest tests/test_milestone3_contract.py tests/test_milestone5_teacher_eval_loop.py tests/test_autoresearch_alpha_loop.py
+python3 -m unittest tests/test_public_benchmark_pack_v1.py -v
+python3 -m unittest tests/test_dataset_flywheel_phase_g.py -v
+python3 -m unittest tests/test_private_holdout_separation.py -v
+python3 -m unittest tests/test_milestone3_contract.py tests/test_milestone5_teacher_eval_loop.py -v
 ```
 
 ## Files
@@ -131,11 +137,12 @@ python3 -m unittest tests/test_milestone3_contract.py tests/test_milestone5_teac
 - `benchmarks/public-pack-v1/episode-family-registry.json`
 - `benchmarks/public-pack-v1/benchmark-pack.json`
 - `data/episode-registry/public-benchmark-pack-v1.json`
+- `data/episode-registry/source-buckets.json`
 - `docs/dataset-episode-registry.md`
+- `docs/dataset-flywheel.md`
 - `benchmarks/private-holdout-pack-template.json`
 - `specs/008-public-benchmark-pack-v1.md`
 - `specs/012-private-holdout-pack.md`
 - `tests/test_public_benchmark_pack_v1.py`
+- `tests/test_dataset_flywheel_phase_g.py`
 - `tests/test_private_holdout_separation.py`
-- `scripts/holdout_author.py`
-- `docs/private-holdout-authoring.md`

--- a/docs/software-engineer-curriculum-sources.md
+++ b/docs/software-engineer-curriculum-sources.md
@@ -15,8 +15,8 @@ Role Foundry does **not** need a giant generic software corpus right now. The fi
 
 What the repo already has is solid but narrow:
 
-- `benchmarks/public-pack-v1/benchmark-pack.json` ships **12 public episodes across 6 public families**
-- those families are all derived from the internal seed scenarios `t1`–`t6`
+- `benchmarks/public-pack-v1/benchmark-pack.json` ships **14 public episodes across 7 public families**
+- those families are all derived from the internal seed scenarios `t1`–`t7`
 - they are strong on:
   - landing-story clarity
   - curriculum vs holdout separation
@@ -24,11 +24,11 @@ What the repo already has is solid but narrow:
   - proof-bundle visibility
   - demo honesty
   - failure -> curriculum promotion
+  - first-wave executable UI regression tasks via the Playwright-informed public family
 - they are **not yet strong** on:
   - true external issue -> patch exemplars
   - stack-adjacent frontend bugfixes
   - explicit code-review comment discipline
-  - executable UI regression tasks
   - accessibility/product-polish references grounded in public standards
 
 That matters because the current apprentice is already a real software role, not a generic “agent” role.
@@ -105,22 +105,22 @@ APG should be used as a **supporting reference** inside the first two additions,
 
 ## Narrow next-step plan for the top 3 additions
 
-### 1. Playwright regression mini-pack
+### 1. Expand the Playwright regression mini-pack
 
-Add one small public family for RF itself, something like:
+The first small public family already shipped in the frozen pack:
 
-- `rf.software-engineer.public.playwright-regression`
+- `rf.frontend-apprentice.public.playwright-regression`
 
-Start with **4-6 episodes** only, tied to current UI surfaces:
+Right now it contributes **2 public episodes** (`pbpv1-e13`, `pbpv1-e14`) tied to real RF screens. If we expand it further, the next step is to grow toward **4-6 episodes** covering nearby UI surfaces such as:
 
-- landing page story clarity stays visible after a copy edit
-- run detail page preserves proof-bundle evidence panels
-- curriculum vs teacher-only labels stay explicit
-- live/read-model fallback stays honest when data is missing
+- landing page story clarity staying visible after a copy edit
+- run detail page preserving proof-bundle evidence panels
+- curriculum vs teacher-only labels staying explicit
+- live/read-model fallback staying honest when data is missing
 
 Rules:
 
-- use role/text/test-id style selectors, not brittle CSS/XPath
+- use role/text/label locators, not brittle CSS/XPath or hidden test IDs
 - every episode should have a visible product reason, not just “more tests”
 - require receipts: failing check, fix, and passing rerun
 
@@ -156,6 +156,6 @@ This gets RF real issue -> patch texture without pretending raw GitHub discussio
 
 ## One best immediate next move
 
-Add the **Playwright regression mini-pack first**.
+Add the **code-review / diff-critique mini-pack next**.
 
-It is the narrowest honest upgrade that immediately improves the current apprentice on exactly the work RF already does: visible frontend changes, regression prevention, receipts, and small-scope bugfixing.
+The first Playwright-informed slice already landed in the frozen public pack, so the next highest-signal gap is review discipline: small-diff critique, blocking-vs-non-blocking comments, test/doc expectations, and uncertainty honesty.

--- a/specs/008-public-benchmark-pack-v1.md
+++ b/specs/008-public-benchmark-pack-v1.md
@@ -7,7 +7,9 @@ Turn the episode-registry / flywheel work into the first **public-safe benchmark
 ## Requirements
 
 1. The public pack must include **only** student-visible, benchmark-ready episode families.
-2. Any family derived from current repo-visible holdout / teacher-only material must be **blocked_pending_rewrite** and excluded from the public pack.
+2. Any family derived from current repo-visible holdout / teacher-only material must be excluded from the public pack and must carry an explicit rewrite-needed readiness state.
+   - legacy family `status` may remain `blocked_pending_rewrite` for compatibility
+   - promotion-planning `readiness_state` must be `rewrite_before_holdout_promotion`
 3. The student-visible vs teacher-only separation must be explicit in machine-readable data.
 4. The public pack must be honest about its scope:
    - usable now for public training / regression loops
@@ -18,11 +20,13 @@ Turn the episode-registry / flywheel work into the first **public-safe benchmark
    - companion episode registry with public rubrics + provenance
    - concrete episodes/prompts
    - verifier guidance
+   - explicit leak-audit and readiness-state evidence
 
 ## Phase B acceptance checkpoints
 
 - **B001 — Public episode count**
   - The pack ships at least 10 concrete public episodes.
+  - Current frozen v1 state is 14 episodes across 7 families.
 - **B002 — Rubric completeness**
   - Every public episode maps to a complete **public rubric template** with explicit dimensions, weights, and pass/fail guidance.
 - **B003 — Weight normalization**
@@ -30,10 +34,17 @@ Turn the episode-registry / flywheel work into the first **public-safe benchmark
 - **B004 — Public/teacher split integrity**
   - The public pack contains only `benchmark_ready` + `student_visible` families.
   - Blocked `teacher_only` families remain excluded and named honestly.
+  - Leak audit on tracked public pack artifacts reports zero teacher-only field/token hits.
 - **B005 — Provenance coverage**
   - Every public episode records public provenance back to its training seed scenario plus the governing public spec/doc references.
+  - Coverage must be at least `>= 90%`; frozen v1 currently records `100%`.
 - **B006 — Promotion readiness clarity**
   - The manifest and docs explicitly say what the pack is ready to promote now, and what remains blocked.
+  - Every candidate family carries a readiness state from the allowed set:
+    - `draft`
+    - `benchmark_ready`
+    - `rewrite_before_holdout_promotion`
+    - `blocked`
   - Promotion readiness here means **public benchmark-pack promotion only**, not sealed certification.
 
 ## Acceptance criteria
@@ -46,6 +57,8 @@ Turn the episode-registry / flywheel work into the first **public-safe benchmark
 - Every public episode maps to a complete public rubric template.
 - Every public rubric template has normalized weights.
 - Every public episode has public provenance coverage.
+- Tracked public pack artifacts carry an explicit leak-audit outcome.
+- Every candidate family carries an explicit readiness state.
 - Tests verify B001–B006 plus the inclusion/exclusion contract.
 
 ## Done when
@@ -53,7 +66,7 @@ Turn the episode-registry / flywheel work into the first **public-safe benchmark
 Role Foundry can honestly say:
 - there is a public benchmark pack the autoresearch loop can use now
 - teacher-only / holdout-derived families are **not** being misrepresented as public-safe
-- public rubrics and provenance are explicit enough to audit
+- public rubrics, provenance, leak-audit evidence, and readiness states are explicit enough to audit
 - the pack is ready to promote for **public regression/training use**
-- future sealed-eval work is clearly marked as blocked pending rewrite
+- future sealed-eval work is clearly marked as rewrite-needed before holdout promotion
 - this is **not a sealed certification exam**

--- a/specs/012-private-holdout-pack.md
+++ b/specs/012-private-holdout-pack.md
@@ -6,7 +6,7 @@ Define the contract for teacher-only holdout evaluation material that must never
 
 ## Background
 
-Public benchmark pack v1 (spec 008) ships 6 public families and 12 episodes. Three holdout-derived families are `blocked_pending_rewrite` because their framing is already repo-visible. To unblock honest sealed evaluation, fresh teacher-only material must be authored with new wording and kept out of all tracked public repo artifacts.
+Public benchmark pack v1 now ships **7 public families and 14 episodes**. Three holdout-derived families remain legacy-status `blocked_pending_rewrite` and readiness-state `rewrite_before_holdout_promotion` because their framing is already repo-visible. To unblock honest sealed evaluation, fresh teacher-only material must be authored with new wording and kept out of all tracked public repo artifacts.
 
 ## What this spec claims
 

--- a/tests/test_public_benchmark_pack_v1.py
+++ b/tests/test_public_benchmark_pack_v1.py
@@ -28,6 +28,12 @@ class PublicBenchmarkPackPhaseBTests(unittest.TestCase):
             rubric["id"]: rubric for rubric in cls.episode_registry["rubric_templates"]
         }
         cls.seed_scenarios = {scenario["id"]: scenario for scenario in cls.seed["scenarios"]}
+        cls.allowed_readiness_states = {
+            "draft",
+            "benchmark_ready",
+            "rewrite_before_holdout_promotion",
+            "blocked",
+        }
 
     def test_B001_public_episode_count(self):
         self.assertTrue(PACK.exists())
@@ -41,6 +47,7 @@ class PublicBenchmarkPackPhaseBTests(unittest.TestCase):
         ]
         self.assertGreaterEqual(len(self.pack_episodes), minimum)
         self.assertEqual(len(self.pack_episodes), 14)
+        self.assertEqual(self.pack["meta"]["public_episode_count"], len(self.pack_episodes))
         self.assertEqual(
             self.episode_registry["coverage"]["public_episode_count"],
             len(self.pack_episodes),
@@ -113,6 +120,7 @@ class PublicBenchmarkPackPhaseBTests(unittest.TestCase):
             family = self.families[family_id]
             self.assertEqual(family["status"], "benchmark_ready")
             self.assertEqual(family["visibility"], "student_visible")
+            self.assertEqual(family["readiness_state"], "benchmark_ready")
             for scenario_id in family["source_seed_scenarios"]:
                 self.assertEqual(self.seed_scenarios[scenario_id]["type"], "training")
 
@@ -120,20 +128,57 @@ class PublicBenchmarkPackPhaseBTests(unittest.TestCase):
             family = self.families[family_id]
             self.assertEqual(family["status"], "blocked_pending_rewrite")
             self.assertEqual(family["visibility"], "teacher_only")
+            self.assertEqual(
+                family["readiness_state"], "rewrite_before_holdout_promotion"
+            )
             self.assertIn("rewrite_requirements", family)
             for scenario_id in family["source_seed_scenarios"]:
                 self.assertEqual(self.seed_scenarios[scenario_id]["type"], "holdout")
 
-        forbidden_tokens = ["teacher_prompt", "judge-only prompt", "grading rubric"]
-        for episode in self.pack["episodes"]:
-            serialized = json.dumps(episode).lower()
-            for token in forbidden_tokens:
+        forbidden_machine_tokens = ["teacher_prompt", "scoring_rubric", "judge-only prompt"]
+        for artifact in (self.pack, self.family_registry, self.episode_registry):
+            serialized = json.dumps(artifact).lower()
+            for token in forbidden_machine_tokens:
                 self.assertNotIn(token, serialized)
+        for episode in self.pack["episodes"]:
+            serialized_episode = json.dumps(episode).lower()
+            self.assertNotIn("grading rubric", serialized_episode)
+
+        integrity_audit = self.pack["integrity_audit"]
+        self.assertEqual(integrity_audit["phase"], "B")
+        self.assertEqual(integrity_audit["status"], "pass")
+        self.assertEqual(integrity_audit["teacher_only_field_hits"], 0)
+        self.assertEqual(integrity_audit["teacher_only_token_hits"], 0)
+        self.assertEqual(
+            integrity_audit["blocked_family_count"], len(self.pack["blocked_family_ids"])
+        )
+        self.assertEqual(
+            set(integrity_audit["scanned_artifacts"]),
+            {
+                "benchmarks/public-pack-v1/benchmark-pack.json",
+                "benchmarks/public-pack-v1/episode-family-registry.json",
+                "data/episode-registry/public-benchmark-pack-v1.json",
+            },
+        )
+        metric = self.pack["promotion_readiness"]["metrics"]["B004"]
+        self.assertEqual(metric["leak_audit_status"], "pass")
+        self.assertEqual(metric["teacher_only_field_hits"], 0)
+        self.assertEqual(metric["teacher_only_token_hits"], 0)
 
     def test_B005_provenance_coverage(self):
         self.assertEqual(
             self.episode_registry["coverage"]["provenance_mapped_episode_count"],
             len(self.pack_episodes),
+        )
+        self.assertEqual(
+            self.episode_registry["coverage"]["public_provenance_coverage_pct"], 100.0
+        )
+        self.assertEqual(self.pack["meta"]["public_provenance_coverage_pct"], 100.0)
+        self.assertEqual(
+            self.pack["promotion_readiness"]["metrics"]["B005"][
+                "actual_provenance_coverage_pct"
+            ],
+            100.0,
         )
         self.assertTrue(self.episode_registry["meta"]["student_visible_only"])
         self.assertFalse(self.episode_registry["meta"]["teacher_only_fields_present"])
@@ -170,6 +215,45 @@ class PublicBenchmarkPackPhaseBTests(unittest.TestCase):
             {"B001", "B002", "B003", "B004", "B005", "B006"},
         )
 
+        policy = self.family_registry["policy"]
+        self.assertEqual(set(policy["allowed_readiness_states"]), self.allowed_readiness_states)
+        self.assertIn("readiness_state_policy", policy)
+        self.assertEqual(
+            self.episode_registry["meta"]["allowed_readiness_states"],
+            policy["allowed_readiness_states"],
+        )
+        for family in self.family_registry["families"]:
+            self.assertIn("readiness_state", family)
+            self.assertIn(family["readiness_state"], self.allowed_readiness_states)
+
+        readiness_metric = readiness["metrics"]["B006"]
+        self.assertEqual(
+            readiness_metric["family_readiness_coverage_count"],
+            len(self.family_registry["families"]),
+        )
+        self.assertEqual(
+            readiness_metric["family_readiness_state_counts"],
+            {
+                "benchmark_ready": len(self.pack["included_family_ids"]),
+                "rewrite_before_holdout_promotion": len(self.pack["blocked_family_ids"]),
+            },
+        )
+        self.assertEqual(
+            set(readiness_metric["allowed_readiness_states"]),
+            self.allowed_readiness_states,
+        )
+        self.assertEqual(
+            self.episode_registry["readiness_summary"],
+            self.family_registry["readiness_summary"],
+        )
+        self.assertEqual(
+            self.episode_registry["coverage"]["family_readiness_coverage_count"],
+            len(self.family_registry["families"]),
+        )
+        self.assertEqual(
+            self.episode_registry["coverage"]["family_readiness_coverage_pct"], 100.0
+        )
+
         doc_text = DOC.read_text().lower().replace("**", "")
         spec_text = SPEC.read_text().lower().replace("**", "")
         for metric in ("b001", "b002", "b003", "b004", "b005", "b006"):
@@ -181,6 +265,21 @@ class PublicBenchmarkPackPhaseBTests(unittest.TestCase):
         self.assertIn("not a sealed certification exam", spec_text)
         self.assertIn("ready to promote", doc_text)
         self.assertIn("named limits", doc_text)
+        self.assertIn("rewrite_before_holdout_promotion", doc_text)
+        self.assertIn("rewrite_before_holdout_promotion", spec_text)
+        self.assertIn(
+            f"{len(self.pack_episodes)} concrete student-visible episodes", doc_text
+        )
+        self.assertIn(
+            f"{len(self.pack['included_family_ids'])} public-ready families", doc_text
+        )
+        self.assertIn(
+            f"{len(self.rubric_templates)} public rubric templates", doc_text
+        )
+        self.assertIn(
+            f"{len(self.pack_episodes)}/{len(self.pack_episodes)} provenance mappings",
+            doc_text,
+        )
 
 
 if __name__ == "__main__":

--- a/tests/test_public_benchmark_pack_v1.py
+++ b/tests/test_public_benchmark_pack_v1.py
@@ -9,6 +9,8 @@ PACK = ROOT / "benchmarks" / "public-pack-v1" / "benchmark-pack.json"
 EPISODE_REGISTRY = ROOT / "data" / "episode-registry" / "public-benchmark-pack-v1.json"
 SPEC = ROOT / "specs" / "008-public-benchmark-pack-v1.md"
 DOC = ROOT / "docs" / "public-benchmark-pack-v1.md"
+SUPPORT_DOC = ROOT / "docs" / "software-engineer-curriculum-sources.md"
+VISION_PAGE = ROOT / "app" / "vision.html"
 SEED = ROOT / "seed" / "role-foundry-apprentice.json"
 
 
@@ -280,6 +282,26 @@ class PublicBenchmarkPackPhaseBTests(unittest.TestCase):
             f"{len(self.pack_episodes)}/{len(self.pack_episodes)} provenance mappings",
             doc_text,
         )
+
+    def test_support_surfaces_match_frozen_pack_counts(self):
+        self.assertTrue(SUPPORT_DOC.exists())
+        self.assertTrue(VISION_PAGE.exists())
+
+        support_text = SUPPORT_DOC.read_text().lower().replace("**", "")
+        vision_text = VISION_PAGE.read_text().lower()
+
+        self.assertIn(
+            f"{len(self.pack_episodes)} public episodes across {len(self.pack['included_family_ids'])} public families",
+            support_text,
+        )
+        self.assertIn("t7", support_text)
+        self.assertIn("playwright", support_text)
+
+        self.assertIn(
+            f"{len(self.pack_episodes)} episodes across {len(self.pack['included_family_ids'])} families",
+            vision_text,
+        )
+        self.assertIn("playwright", vision_text)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary
- keep Phase B scoped to the public benchmark-pack honesty lane
- sync stale support surfaces to the frozen 14-episode / 7-family public-pack truth
- add a regression test so support docs and the vision page cannot silently drift behind B001/B006 again

## Files touched
- `app/vision.html`
- `docs/software-engineer-curriculum-sources.md`
- `tests/test_public_benchmark_pack_v1.py`

## Validation
- `python3 -m unittest tests/test_public_benchmark_pack_v1.py tests/test_private_holdout_separation.py tests/test_dataset_flywheel_phase_g.py tests/test_teacher_source_curriculum.py -v`
- `git diff --check`

## Honesty notes
- public pack remains 14 episodes across 7 benchmark-ready families
- blocked teacher-only families remain excluded and explicitly marked `rewrite_before_holdout_promotion`
- no core loop contracts, teacher-only leakage rules, or unrelated UI semantics were changed
